### PR TITLE
fix exit status

### DIFF
--- a/script/relpath
+++ b/script/relpath
@@ -57,7 +57,7 @@ sub run {
         say File::Spec->abs2rel($_);
     }
 
-    exit $has_error ? 1:0;
+    exit($has_error ? 1 : 0);
 }
 
 # MAIN


### PR DESCRIPTION
`exit` has higher precedence than `?:`, so `exit $has_error ? 1:0` parses as `(exit $has_error) ? 1 : 0`, which is not what was intended.